### PR TITLE
docs(readme): move config section higher

### DIFF
--- a/README-default.md
+++ b/README-default.md
@@ -19,7 +19,7 @@ awesome-project "Do something!"  # prints "Nah."
 
 Here you should say what actually happens when you execute the code above.
 
-## Initial Configuration
+### Initial Configuration
 
 Some projects require initial configuration (e.g. access tokens or keys, `npm i`).
 This is the section where you would document those requirements.

--- a/README-default.md
+++ b/README-default.md
@@ -19,10 +19,10 @@ awesome-project "Do something!"  # prints "Nah."
 
 Here you should say what actually happens when you execute the code above.
 
-## Configuration
+## Initial Configuration
 
-Here you should write what are all of the configurations a user can enter when
-using the project.
+Some projects require initial configuration (e.g. access tokens or keys, `npm i`).
+This is the section where you would document those requirements.
 
 ## Developing
 
@@ -68,6 +68,11 @@ What's all the bells and whistles this project can perform?
 * What's the main functionality
 * You can also do another thing
 * If you get really randy, you can even do this
+
+## Configuration
+
+Here you should write what are all of the configurations a user can enter when
+using the project.
 
 #### Argument 1
 Type: `String`  

--- a/README-default.md
+++ b/README-default.md
@@ -19,6 +19,11 @@ awesome-project "Do something!"  # prints "Nah."
 
 Here you should say what actually happens when you execute the code above.
 
+## Configuration
+
+Here you should write what are all of the configurations a user can enter when
+using the project.
+
 ## Developing
 
 Here's a brief intro about what a developer must do in order to start developing
@@ -63,11 +68,6 @@ What's all the bells and whistles this project can perform?
 * What's the main functionality
 * You can also do another thing
 * If you get really randy, you can even do this
-
-## Configuration
-
-Here you should write what are all of the configurations a user can enter when
-using the project.
 
 #### Argument 1
 Type: `String`  


### PR DESCRIPTION
I would recommend moving the configuration section higher as users might need that even before development or building.