### PR TITLE
Remove reference to Atom as it is archived.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Readme Best Practices
 > A place to copy-paste your README.md from
 
-One of the most crucial things in your open source project is the `README.md`
+One of the most crucial things in your open-source project is the `README.md`
 file. This repository has a ready-to-copy-paste template you can use for all
 your projects.
 
@@ -19,14 +19,14 @@ renames it to `README.md`.
 
 ## Fill with your own text
 
-The default template has some guiding text to get you started. However you'll
+The default template has some guiding text to get you started. However, you'll
 need to edit the file with your own text to use it with your project.
 
 ```shell
-atom README.md
+code README.md
 ```
 
-If you're using [Atom](https://atom.io/) code editor, the code above opens the
+If you're using [VS Code](https://code.visualstudio.com/) code editor, the code above opens the
 file for editing. If necessary, substitute with your preferred markdown editor.
 
 ### Add to git and push
@@ -41,12 +41,12 @@ git push
 ```
 
 This adds the `README.md` file to your git repository, creates a commit for it
-and pushes it to GitHub (or other preferred remote repository).
+and pushes it to GitHub (or your preferred remote repository).
 
 ## Features
 
 This project makes it easy to:
-* Bootstrap your open source project properly
+* Bootstrap your open-source project properly
 * Make sure everyone gets what you're trying to achieve with your project
 * Follow simple instructions for a perfect `README.md`
 
@@ -60,7 +60,7 @@ If you'd like to contribute, please fork the repository and make changes as
 you'd like. Pull requests are warmly welcome.
 
 If your vision of a perfect `README.md` differs greatly from mine, it might be
-because your projects are for vastly different. In this case, you can create a
+because your projects are vastly different. In this case, you can create a
 new file `README-yourplatform.md` and create the perfect boilerplate for that.
 
 E.g. if you have a perfect `README.md` for a Grunt project, just name it as
@@ -78,7 +78,7 @@ creating the best possible README for your own project:
 
 ## Licensing
 
-This project is licensed under Unlicense license. This license does not require
+This project is licensed under an Unlicense license. This license does not require
 you to take the license with you to your project.
 
 [issues]:https://github.com/jehna/readme-best-practices/issues/new


### PR DESCRIPTION
- Update `Atom` to `VS Code` as Atom was sunsetted in Dec 2022.
- Minor grammar fixes

[Source Reference](https://github.blog/2022-06-08-sunsetting-atom/)