### PR TITLE
Add an animated hero to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Readme Best Practices
 > A place to copy-paste your README.md from
 
+![Demo: a project with an empty README.md runs one curl command to fetch README-default.md, a template with seven ready-made sections — Installing, Developing, Features, Configuration, Contributing, Links and Licensing — then fills in the blanks and pushes with git.](assets/hero.gif)
+
 One of the most crucial things in your open-source project is the `README.md`
 file. This repository has a ready-to-copy-paste template you can use for all
 your projects.


### PR DESCRIPTION
The repo teaches people to start their READMEs with a visual, but its own README didn't have one — so here's a hero GIF that shows the whole flow in 20 seconds: empty README, the curl one-liner, the template's seven sections building up, then `git add && commit && push`.

![preview](https://raw.githubusercontent.com/livlign/readme-best-practices/docs/add-hero-gif/assets/hero.gif)

Everything on screen comes from the repo itself — the actual curl command, the real section names from `README-default.md`, and the sample logo. 1200×675, ~5 MB, loops cleanly.

Happy to tweak pacing, copy, or drop it entirely if it's not your taste.

---
*Generated with [repo-visuals](https://github.com/livlign/claude-skills)*